### PR TITLE
feat : 카카오 지오 keyword 검색

### DIFF
--- a/src/main/java/com/groom/marky/controller/GoogleMapController.java
+++ b/src/main/java/com/groom/marky/controller/GoogleMapController.java
@@ -20,6 +20,7 @@ import com.groom.marky.service.impl.SeoulPlaceSearchService;
 import com.groom.marky.service.impl.GooglePlaceSearchServiceImpl;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Slf4j
 @Controller
@@ -99,5 +100,13 @@ public class GoogleMapController {
 		GooglePlacesApiResponse response = googlePlaceSearchService.searchNearby(List.of("restaurant"), box);
 
 		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@GetMapping("/activity")
+	public ResponseEntity<?> getActivity(@RequestParam("keyword") String keyword) {
+		List<GooglePlacesApiResponse.Place> activityBoxes = seoulPlaceSearchService.getActivityRects(keyword);
+		log.info("activityBoxes {}", activityBoxes.size());
+
+		return new ResponseEntity<>(activityBoxes, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/groom/marky/service/GooglePlaceSearchService.java
+++ b/src/main/java/com/groom/marky/service/GooglePlaceSearchService.java
@@ -1,6 +1,7 @@
 package com.groom.marky.service;
 
 import java.util.List;
+import java.util.Set;
 
 import com.groom.marky.common.constant.GooglePlaceType;
 import com.groom.marky.domain.request.Rectangle;
@@ -11,5 +12,7 @@ public interface GooglePlaceSearchService {
 	GooglePlacesApiResponse search(String text, GooglePlaceType type, Rectangle box);
 
 	GooglePlacesApiResponse searchNearby(List<String> types, Rectangle box);
+
+	List<GooglePlacesApiResponse.Place> search(String text, Set<Rectangle> boxes);
 
 }

--- a/src/main/java/com/groom/marky/service/KakaoPlaceSearchService.java
+++ b/src/main/java/com/groom/marky/service/KakaoPlaceSearchService.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import com.groom.marky.domain.request.Rectangle;
 import com.groom.marky.common.constant.KakaoMapCategoryGroupCode;
+import com.groom.marky.domain.response.GooglePlacesApiResponse;
 
 public interface KakaoPlaceSearchService {
 
@@ -13,6 +14,8 @@ public interface KakaoPlaceSearchService {
 
 	// 사각형 내에 존재하는 특정 카테고리 토탈 카운트
 	int getTotalCount(String rect, KakaoMapCategoryGroupCode code);
+
+	int getTotalCount(String rect, String keyword);
 
 	// 카테고리 검색
 	Map<String, String> search(String rect, KakaoMapCategoryGroupCode code);
@@ -24,4 +27,6 @@ public interface KakaoPlaceSearchService {
 	Map<String, String> search(String rect, String keyword);
 
 	Set<Rectangle> getRects(List<Rectangle> boxes, KakaoMapCategoryGroupCode categoryGroupCode);
+
+	List<GooglePlacesApiResponse.Place> getRects(List<Rectangle> boxes, String keyword);
 }

--- a/src/main/java/com/groom/marky/service/impl/SeoulPlaceSearchService.java
+++ b/src/main/java/com/groom/marky/service/impl/SeoulPlaceSearchService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.groom.marky.domain.response.GooglePlacesApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -51,5 +52,8 @@ public class SeoulPlaceSearchService {
 		return kakaoPlaceSearchService.getRects(seoulBoxes, PK6);
 	}
 
+	public List<GooglePlacesApiResponse.Place> getActivityRects(String keyword) {
+		return kakaoPlaceSearchService.getRects(seoulBoxes, keyword);
+	}
 }
 


### PR DESCRIPTION
GoogleMapController

getActivity()
- keyword 기반 activity 정보 조회

KakaoPlaceSearchService

getTotalCount()
- 기존 code 파라미터 방식을 keyword 방식으로 변경하여 추가

getRects()
- 기존 code 파라미터 방식을 keyword 방식으로 변경하여 추가
- Return : List<GooglePlacesApiResponse.Place>
  - 구글 리뷰가 포함된 정보 반환
1. 기존 getRects()와 동일
2. googlePlaceSearchService.search(keyword, kakaoResult)를 호출하여 구글 리뷰를 포함한 정보 추출

GooglePlaceSearchServiceImpl

search()
- keyword기반으로 구글 리뷰 조회하는 함수
1. 기존 방식과 동일