### PR TITLE
[FEAT] 카카오 키워드 서치 및 챗메모리 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ out/
 
 
 .env
-.env

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
+		id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -44,8 +44,6 @@ dependencies {
 	implementation 'org.springframework.ai:spring-ai-advisors-vector-store'
 
 
-	// implementation 'org.bsc.langgraph4j:langgraph4j-core:1.5.13'
-
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -53,12 +51,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
+	// chat memory repository
+	implementation 'org.springframework.ai:spring-ai-starter-model-chat-memory-repository-neo4j'
 
 	// data jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
-	//implementation 'org.springframework.ai:spring-ai-advisors-vector-store'
-
 
 	// postgresql, pgvector
 	implementation 'org.springframework.ai:spring-ai-starter-vector-store-pgvector'

--- a/src/main/java/com/groom/marky/config/ChatClientConfig.java
+++ b/src/main/java/com/groom/marky/config/ChatClientConfig.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.groom.marky.common.TmapGeocodingClient;
 import com.groom.marky.common.TmapTransitClient;
+import com.groom.marky.service.KakaoPlaceSearchService;
 import com.groom.marky.service.advisor.LocationResolverAdvisor;
 import com.groom.marky.service.advisor.MultiPurposeActionAdvisor;
 import com.groom.marky.service.advisor.SubwayRouteAdvisor;
@@ -35,8 +36,6 @@ public class ChatClientConfig {
 			.maxMessages(10)
 			.build();
 	}
-
-
 
 	@Bean
 	public ChatClient chatClient(
@@ -96,8 +95,8 @@ public class ChatClientConfig {
 	}
 
 	@Bean
-	public LocationResolverAdvisor locationResolverAdvisor(TmapGeocodingClient tmapGeocodingClient) {
-		return new LocationResolverAdvisor(tmapGeocodingClient);
+	public LocationResolverAdvisor locationResolverAdvisor(KakaoPlaceSearchService kakaoPlaceSearchService) {
+		return new LocationResolverAdvisor(kakaoPlaceSearchService);
 	}
 
 	@Bean

--- a/src/main/java/com/groom/marky/config/ChatClientConfig.java
+++ b/src/main/java/com/groom/marky/config/ChatClientConfig.java
@@ -3,6 +3,9 @@ package com.groom.marky.config;
 import java.util.List;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.support.ToolCallbacks;
@@ -27,7 +30,17 @@ import com.groom.marky.service.tool.RedisGeoSearchTool;
 public class ChatClientConfig {
 
 	@Bean
+	public ChatMemory chatMemory() {
+		return MessageWindowChatMemory.builder()
+			.maxMessages(10)
+			.build();
+	}
+
+
+
+	@Bean
 	public ChatClient chatClient(
+		ChatMemory chatMemory,
 		ChatModel model,
 		SystemRoleAdvisor systemRoleAdvisor,
 		UserIntentAdvisor userIntentAdvisor,
@@ -47,7 +60,8 @@ public class ChatClientConfig {
 				systemRoleAdvisor,
 				userIntentAdvisor,
 				locationResolverAdvisor,
-				multiPurposeActionAdvisor
+				multiPurposeActionAdvisor,
+				MessageChatMemoryAdvisor.builder(chatMemory).build()
 			))
 			.build();
 	}

--- a/src/main/java/com/groom/marky/controller/KakaoMapController.java
+++ b/src/main/java/com/groom/marky/controller/KakaoMapController.java
@@ -1,5 +1,6 @@
 package com.groom.marky.controller;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,8 +9,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.groom.marky.domain.request.Rectangle;
+import com.groom.marky.service.KakaoPlaceSearchService;
+import com.groom.marky.service.impl.KakaoPlaceSearchServiceImpl;
 import com.groom.marky.service.impl.SeoulPlaceSearchService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -20,10 +24,13 @@ import lombok.extern.slf4j.Slf4j;
 public class KakaoMapController {
 
 	private final SeoulPlaceSearchService seoulPlaceSearchService;
+	private final KakaoPlaceSearchService kakaoPlaceSearchService;
 
 	@Autowired
-	public KakaoMapController(SeoulPlaceSearchService seoulPlaceSearchService) {
+	public KakaoMapController(SeoulPlaceSearchService seoulPlaceSearchService,
+		KakaoPlaceSearchService kakaoPlaceSearchService) {
 		this.seoulPlaceSearchService = seoulPlaceSearchService;
+		this.kakaoPlaceSearchService = kakaoPlaceSearchService;
 	}
 
 	@GetMapping("/parkinglot")
@@ -46,10 +53,20 @@ public class KakaoMapController {
 
 	@GetMapping("/cafe")
 	public ResponseEntity<?> getCafes() {
-		// 박스 받아서 박스 범위 내의 주차장 조회 - 2000건
 		Set<Rectangle> cafeBoxes = seoulPlaceSearchService.getCafeRects();
 		log.info("cafeBoxes {}", cafeBoxes.size());
-
 		return new ResponseEntity<>(cafeBoxes, HttpStatus.OK);
+	}
+
+
+	@GetMapping("/search")
+	public ResponseEntity<?> searchKeyword(@RequestParam("keyword") String keyword) {
+
+
+		Map<String, Double> search = kakaoPlaceSearchService.search(keyword);
+
+		log.info("search result : {}", search);
+
+		return new ResponseEntity<>(HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/groom/marky/domain/request/LocationRestriction.java
+++ b/src/main/java/com/groom/marky/domain/request/LocationRestriction.java
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(
 	use = JsonTypeInfo.Id.NAME,
-	include = JsonTypeInfo.As.WRAPPER_OBJECT,
-	property = ""
+	include = JsonTypeInfo.As.WRAPPER_OBJECT
 )
 @JsonSubTypes({
 	@JsonSubTypes.Type(value = Rectangle.class, name = "rectangle"),

--- a/src/main/java/com/groom/marky/service/KakaoPlaceSearchService.java
+++ b/src/main/java/com/groom/marky/service/KakaoPlaceSearchService.java
@@ -23,8 +23,9 @@ public interface KakaoPlaceSearchService {
 	// 범위 내 특정 카테고리를 가진 모든 장소 반환
 	Map<String, String> searchAll(List<Rectangle> boxes, KakaoMapCategoryGroupCode code);
 
-	// 키워드 검색
-	Map<String, String> search(String rect, String keyword);
+	// 키워드 검색, 첫번째 응답값의  위경도 반환
+	Map<String, Double> search(String keyword);
+
 
 	Set<Rectangle> getRects(List<Rectangle> boxes, KakaoMapCategoryGroupCode categoryGroupCode);
 

--- a/src/main/java/com/groom/marky/service/advisor/LocationResolverAdvisor.java
+++ b/src/main/java/com/groom/marky/service/advisor/LocationResolverAdvisor.java
@@ -31,12 +31,16 @@ import lombok.extern.slf4j.Slf4j;
 		log.info("[LocationResolverAdvisor] 진입");
 
 		String location = (String) request.context().get(LOCATION_KEY);
+
+
 		if (location == null || location.isBlank()) {
 			log.warn("location이 누락되어 LocationResolverAdvisor 스킵");
 			return chain.nextCall(request);
 		}
 
 		Map<String, Double> coord = tmapClient.getLatLon(location);
+
+
 		if (coord == null) {
 			log.warn("tmapClient 결과가 null → location: {}", location);
 			return chain.nextCall(request);

--- a/src/main/java/com/groom/marky/service/advisor/LocationResolverAdvisor.java
+++ b/src/main/java/com/groom/marky/service/advisor/LocationResolverAdvisor.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Description;
 
 import com.groom.marky.common.TmapGeocodingClient;
+import com.groom.marky.service.KakaoPlaceSearchService;
+import com.groom.marky.service.impl.KakaoPlaceSearchServiceImpl;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,12 +20,13 @@ import lombok.extern.slf4j.Slf4j;
 	public class LocationResolverAdvisor implements CallAdvisor {
 
 	private static final String LOCATION_KEY = "location";
-	private final TmapGeocodingClient tmapClient;
+	private final KakaoPlaceSearchService kakaoPlaceSearchService;
 
 	@Autowired
-	public LocationResolverAdvisor(TmapGeocodingClient tmapClient) {
-		this.tmapClient = tmapClient;
+	public LocationResolverAdvisor(KakaoPlaceSearchService kakaoPlaceSearchService) {
+		this.kakaoPlaceSearchService = kakaoPlaceSearchService;
 	}
+
 
 	@Override
 	public ChatClientResponse adviseCall(ChatClientRequest request, CallAdvisorChain chain) {
@@ -34,25 +37,24 @@ import lombok.extern.slf4j.Slf4j;
 
 
 		if (location == null || location.isBlank()) {
-			log.warn("location이 누락되어 LocationResolverAdvisor 스킵");
+			log.warn("[LocationResolverAdvisor] location 이 누락되어 해당 어드바이저는 스킵합니다.");
 			return chain.nextCall(request);
 		}
 
-		Map<String, Double> coord = tmapClient.getLatLon(location);
+		Map<String, Double> coordination = kakaoPlaceSearchService.search(location);
 
 
-		if (coord == null) {
-			log.warn("tmapClient 결과가 null → location: {}", location);
+		if (coordination == null) {
+			log.warn("[LocationResolverAdvisor] kakaoPlaceSearchService.search 결과가 null 입니다. 해당 어드바이저는 스킵합니다. location: {}", location);
 			return chain.nextCall(request);
 		}
 
-		log.info("[LocationResolverAdvisor] location '{}' → lat={}, lon={}",
-			location, coord.get("lat"), coord.get("lon"));
+		log.info("[LocationResolverAdvisor] location '{}' → lat={}, lon={}", location, coordination.get("lat"), coordination.get("lon"));
 
 		//  여기만 mutate()로 변경
 		ChatClientRequest modified = request.mutate()
-			.context("lat", coord.get("lat"))
-			.context("lon", coord.get("lon"))
+			.context("lat", coordination.get("lat"))
+			.context("lon", coordination.get("lon"))
 			.build();
 
 		return chain.nextCall(modified);

--- a/src/main/java/com/groom/marky/service/advisor/MultiPurposeActionAdvisor.java
+++ b/src/main/java/com/groom/marky/service/advisor/MultiPurposeActionAdvisor.java
@@ -22,6 +22,7 @@ public class MultiPurposeActionAdvisor implements CallAdvisor {
 		- 사용자의 현재 위치를 기준으로 주변 주차장의 고유 ID 목록을 조회합니다.
 		- 반환된 ID 리스트는 이후 추천할 대상의 범위를 한정할 때 사용됩니다.
 		
+		
 		2. similaritySearch(mood: String, ids: List<String>)
 		- 사용자가 원하는 분위기(mood)와 의미적으로 유사한 장소를 5개 추천합니다.
 		- 이 함수는 pgvector 기반의 벡터 임베딩을 사용하여 장소 설명과 mood 간의 의미 유사도를 비교합니다.
@@ -42,8 +43,8 @@ public class MultiPurposeActionAdvisor implements CallAdvisor {
 		- mood 값은 자연어 그대로 전달하면 됩니다. 예: mood="리뷰가 좋은"
 		
 		[예시]
-		- '리뷰가 좋은 주차장을 추천해줘' → similaritySearch(mood="리뷰가 좋은", ids=[...])
-		- '조용하고 쾌적한 주차장' → similaritySearch(mood="조용하고 쾌적한", ids=[...])
+		- '리뷰가 좋은 주차장을 추천해줘' → searchParkingLots(lat : Double, lon : Double) -> similaritySearch(mood="리뷰가 좋은", ids=[...])
+		- '조용하고 쾌적한 주차장' → searchParkingLots(lat : Double, lon : Double) -> similaritySearch(mood="조용하고 쾌적한", ids=[...])
 		
 		요청에 맞는 툴을 위 형식대로 호출해 주세요.
 		""";
@@ -74,8 +75,6 @@ public class MultiPurposeActionAdvisor implements CallAdvisor {
 		ChatClientResponse response = chain.nextCall(updatedRequest);
 
 		// 결과 로깅
-		log.info("api 응답: {}", response.chatResponse().getResult().getOutput());
-		log.info("toolCalls: {}", response.chatResponse().getResult().getOutput().getToolCalls());
 		log.info("metadata: {}", response.chatResponse().getResult().getOutput().getMetadata());
 
 		return response;

--- a/src/main/java/com/groom/marky/service/advisor/UserIntentAdvisor.java
+++ b/src/main/java/com/groom/marky/service/advisor/UserIntentAdvisor.java
@@ -79,6 +79,8 @@ public class UserIntentAdvisor implements CallAdvisor {
 		));
 
 		String json = chatModel.call(prompt).getResult().getOutput().getText();
+
+
 		if (!json.trim().startsWith("{")) {
 			log.warn("LLM 응답이 JSON이 아님: {}", json);
 			return chain.nextCall(request);

--- a/src/main/java/com/groom/marky/service/impl/EmbeddingService.java
+++ b/src/main/java/com/groom/marky/service/impl/EmbeddingService.java
@@ -41,7 +41,6 @@ public class EmbeddingService {
 				String description = descriptionBuilder.buildDescription(place);
 				String id = UUID.nameUUIDFromBytes(place.id().getBytes(StandardCharsets.UTF_8)).toString();
 
-
 				return new Document(
 					id,
 					description, // 자연어

--- a/src/main/java/com/groom/marky/service/impl/KakaoPlaceSearchServiceImpl.java
+++ b/src/main/java/com/groom/marky/service/impl/KakaoPlaceSearchServiceImpl.java
@@ -157,23 +157,26 @@ public class KakaoPlaceSearchServiceImpl implements KakaoPlaceSearchService {
 	 */
 	@Override
 	public Map<String, Double> search(String keyword) {
-
 		HashMap<String, Double> result = new HashMap<>();
-		URI uri = buildKeywordUri(keyword);
-		JsonNode documents = null;
 
-		ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.GET, httpEntity, String.class);
-		log.info("response : {}", response);
+		try {
+			URI uri = buildKeywordUri(keyword);
 
+			ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.GET, httpEntity, String.class);
 
-		JsonNode firstNode = documents.get(0);
-		JsonNode lat = firstNode.get("y");
-		JsonNode lon = firstNode.get("x");
+			String body = response.getBody();
+			JsonNode root = objectMapper.readTree(body);
+			JsonNode documents = root.path("documents");
+			JsonNode firstNode = documents.get(0);
 
-		result.put("lat", Double.parseDouble(lat.textValue()));
-		result.put("lon", Double.parseDouble(lon.textValue()));
+			result.put("lat", Double.parseDouble(firstNode.get("y").textValue()));
+			result.put("lon", Double.parseDouble(firstNode.get("x").textValue()));
 
+		} catch (Exception e) {
+			log.info("[KakaoPlaceSearchServiceImpl] search 예외 발생  keyword : {}, message : {} ", keyword, e.getMessage());
+		}
 		return result;
+
 	}
 
 	@Override

--- a/src/main/java/com/groom/marky/service/impl/KakaoPlaceSearchServiceImpl.java
+++ b/src/main/java/com/groom/marky/service/impl/KakaoPlaceSearchServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.groom.marky.domain.response.GooglePlacesApiResponse;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -18,6 +19,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -44,7 +46,6 @@ public class KakaoPlaceSearchServiceImpl implements KakaoPlaceSearchService {
 	private final ObjectMapper objectMapper;
 	private final GooglePlaceSearchServiceImpl googlePlaceSearchService;
 
-
 	private static final String KEYWORD_SEARCH_API_URI = "https://dapi.kakao.com/v2/local/search/keyword.json";
 	private static final String CATEGORY_SEARCH_API_URI = "https://dapi.kakao.com/v2/local/search/category.json";
 	private static final String ACCURACY_SORT = "accuracy";
@@ -52,14 +53,15 @@ public class KakaoPlaceSearchServiceImpl implements KakaoPlaceSearchService {
 
 	@Autowired
 	public KakaoPlaceSearchServiceImpl(
-            RestTemplate restTemplate,
-            ObjectMapper objectMapper,
-            @Value("${KAKAO_REST_API_KEY}") String apiKey, GooglePlaceSearchServiceImpl googlePlaceSearchService // 이렇게 주입하면 되는군
+		RestTemplate restTemplate,
+		ObjectMapper objectMapper,
+		@Value("${KAKAO_REST_API_KEY}") String apiKey, GooglePlaceSearchServiceImpl googlePlaceSearchService
+		// 이렇게 주입하면 되는군
 	) {
 		this.restTemplate = restTemplate;
 		this.objectMapper = objectMapper;
 		this.apiKey = apiKey;
-        this.googlePlaceSearchService = googlePlaceSearchService;
+		this.googlePlaceSearchService = googlePlaceSearchService;
 
 		// 한 번만 생성해서 재사용 가능한 final 필드로 초기화
 		HttpHeaders headers = new HttpHeaders();
@@ -101,8 +103,6 @@ public class KakaoPlaceSearchServiceImpl implements KakaoPlaceSearchService {
 					if (!province.startsWith("서울") || result.containsKey(id)) {
 						continue;
 					}
-
-					//log.info("placeName : {}, addressName : {}", placeName, addressName);
 					result.put(id, placeName);
 				}
 
@@ -147,10 +147,33 @@ public class KakaoPlaceSearchServiceImpl implements KakaoPlaceSearchService {
 		return result;
 	}
 
-
+	/**
+	 *
+	 * @param
+	 * keyword 검색 키워드
+	 *
+	 * @return
+	 * Map<String, Double> lat : 위도값, lon : 경도값
+	 */
 	@Override
-	public Map<String, String> search(String rect, String keyword) {
-		return Map.of();
+	public Map<String, Double> search(String keyword) {
+
+		HashMap<String, Double> result = new HashMap<>();
+		URI uri = buildKeywordUri(keyword);
+		JsonNode documents = null;
+
+		ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.GET, httpEntity, String.class);
+		log.info("response : {}", response);
+
+
+		JsonNode firstNode = documents.get(0);
+		JsonNode lat = firstNode.get("y");
+		JsonNode lon = firstNode.get("x");
+
+		result.put("lat", Double.parseDouble(lat.textValue()));
+		result.put("lon", Double.parseDouble(lon.textValue()));
+
+		return result;
 	}
 
 	@Override
@@ -165,7 +188,7 @@ public class KakaoPlaceSearchServiceImpl implements KakaoPlaceSearchService {
 			JsonNode meta = objectMapper.readTree(response.getBody()).path("meta");
 			result = meta.path("total_count").asInt();
 		} catch (JsonProcessingException e) {
-			log.info("searchTotalParkingLotCountByRect 예외 발생 : {}", e.getMessage());
+			log.info("[KakaoPlaceSearchServiceImpl] searchTotalParkingLotCountByRect 예외 발생 : {}", e.getMessage());
 		}
 		return result;
 	}
@@ -242,6 +265,15 @@ public class KakaoPlaceSearchServiceImpl implements KakaoPlaceSearchService {
 		return result;
 	}
 
+	private static URI buildKeywordUri(String keyword) {
+		return UriComponentsBuilder.fromUriString(KEYWORD_SEARCH_API_URI)
+			.queryParam("page", 1)
+			.queryParam("size", 1)
+			.queryParam("query", keyword)
+			.queryParam("sort", ACCURACY_SORT)
+			.encode(StandardCharsets.UTF_8)
+			.build().toUri();
+	}
 
 	private static URI buildKeywordUri(String rect, String keyword) {
 		return UriComponentsBuilder.fromUriString(KEYWORD_SEARCH_API_URI)

--- a/src/main/java/com/groom/marky/service/impl/SeoulPlaceSearchService.java
+++ b/src/main/java/com/groom/marky/service/impl/SeoulPlaceSearchService.java
@@ -21,6 +21,8 @@ public class SeoulPlaceSearchService {
 
 	private final KakaoPlaceSearchService kakaoPlaceSearchService;
 	private static final Rectangle seoulBox = Rectangle.rectOfSeoul();
+
+	// 서울을 10 X 10 으로 나눔
 	private static final List<Rectangle> seoulBoxes = seoulBox.generateGrid(10, 10);
 
 	@Autowired
@@ -45,10 +47,12 @@ public class SeoulPlaceSearchService {
 	}
 
 	public Set<Rectangle> getRestaurantRects() {
+
 		return kakaoPlaceSearchService.getRects(seoulBoxes, FD6);
 	}
 
 	public Set<Rectangle> getParkingLotRects() {
+
 		return kakaoPlaceSearchService.getRects(seoulBoxes, PK6);
 	}
 

--- a/src/main/java/com/groom/marky/service/tool/PlaceVectorSearchTool.java
+++ b/src/main/java/com/groom/marky/service/tool/PlaceVectorSearchTool.java
@@ -36,7 +36,8 @@ public class PlaceVectorSearchTool {
 	)
 	public List<Document> similaritySearch(
 		@ToolParam(description = "사용자가 원하는 분위기", required = true) String mood,
-		@ToolParam(description = "지정된 장소 리스트. 해당 아이디로 벡터 데이터베이스 메타데이터 조회. 대상 선정", required = true) List<String> ids) {
+		@ToolParam(description = "지정된 장소 리스트. 해당 아이디로 벡터 데이터베이스 메타데이터 조회. 대상 선정", required = true) List<String> ids
+	) {
 		log.info("[similaritySearch Tool 호출] mood : {}, ids : {}", mood, ids.size());
 
 
@@ -47,6 +48,7 @@ public class PlaceVectorSearchTool {
 
 		FilterExpressionBuilder b = new FilterExpressionBuilder();
 		FilterExpressionBuilder.Op op = null;
+
 
 
 		// 메타데이터에서 구글 플레이스 ID 검색
@@ -65,7 +67,7 @@ public class PlaceVectorSearchTool {
 		return vectorStore.similaritySearch(
 			SearchRequest.builder()
 				.query(mood)
-				.topK(3)
+				.topK(5)
 				.similarityThreshold(0.6)
 				.filterExpression(op.build())
 				.build());

--- a/src/main/java/com/groom/marky/service/tool/RedisGeoSearchTool.java
+++ b/src/main/java/com/groom/marky/service/tool/RedisGeoSearchTool.java
@@ -42,9 +42,9 @@ public class RedisGeoSearchTool {
 		log.info("[searchParkingLots Tool 호출] 위도 : {}, 경도 : {}", lat, lon);
 
 		String key = RedisKeyParser.getPlaceKey(GooglePlaceType.PARKING);
+		// place:parking
 
 		// 필요한건?? 근처 주차장 조회다..
-
 		return redisService.getNearbyPlacesId(key, lat, lon, 2);
 
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,18 +28,11 @@ spring:
           temperature: 0.4
           internal-tool-execution-enabled: true
 
-#      embedding:
-#        api-key: ${OPEN_AI_API_KEY}
-#        options:
-#          model: text-embedding-3-small
-#          dimensions: 768
-
     ollama:
       base-url: http://localhost:11434
       embedding:
         options:
-          # model: mxbai-embed-large
-          model : jeffh/intfloat-multilingual-e5-large-instruct:q8_0
+          model : nomic-embed-text
           keep-alive: 5m
 
     vectorstore:

--- a/src/test/java/com/groom/marky/service/impl/KakaoPlaceSearchServiceImplTest.java
+++ b/src/test/java/com/groom/marky/service/impl/KakaoPlaceSearchServiceImplTest.java
@@ -1,0 +1,143 @@
+package com.groom.marky.service.impl;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@SpringBootTest
+@Import(KakaoPlaceSearchServiceImpl.class)
+class KakaoPlaceSearchServiceImplTest {
+
+	@Autowired
+	private KakaoPlaceSearchServiceImpl kakaoPlaceSearchService;
+
+	/**
+	 * 무엇을 테스트하고싶은지?
+	 * 해당 메서드 내부에서 외부 API 를 호출한다.
+	 * 정상인 상황과 예외 반환 상황을 테스트한다.
+	 *
+	 * 해야 할 일은, 외부 API가 정상으로 왔을 때, 원하는 응답의 형태로 오는지, 그리고 예외 발생 시 예외 처리가 가능한지.
+	 */
+
+	/**
+	 * 조회 관련 테스트 그룹
+	 */
+	@Nested
+	@DisplayName("API 호출 관련 테스트")
+	class CallApiTests {
+
+		@Autowired
+		private RestTemplate restTemplate;
+
+		private static final String KEYWORD_SEARCH_API_URI = "https://dapi.kakao.com/v2/local/search/keyword.json";
+		private static final String ACCURACY_SORT = "accuracy";
+
+		private MockRestServiceServer mockServer;
+
+		@BeforeEach
+		void setUp() {
+			mockServer = MockRestServiceServer.createServer(restTemplate);
+		}
+
+		@AfterEach
+		void clear() {
+			mockServer.reset();
+		}
+
+		/**
+		 * kakaoPlaceSearchService.search(keyword)가 응답의 documents[0].x/y를 정확히 파싱해서 Map<String, Double>에 넣는지 검증.
+		 */
+		@Test
+		@DisplayName("카카오 키워드 서치 API 호출 - 성공 케이스")
+		void kakaoApiKeywordSearchTest() {
+
+			// Given : RestTemplate Response Body 생성
+			String keyword = "서울역";
+			String jsonResponse = """
+				{
+				  "documents": [
+				    {
+				      "address_name": "서울 중구 봉래동2가 122-11",
+				      "category_group_code": "",
+				      "category_group_name": "",
+				      "category_name": "교통,수송 > 기차,철도 > 기차역 > KTX정차역",
+				      "distance": "",
+				      "id": "9113903",
+				      "phone": "1544-7788",
+				      "place_name": "서울역",
+				      "place_url": "http://place.map.kakao.com/9113903",
+				      "road_address_name": "서울 중구 한강대로 405",
+				      "x": "126.97070335253385",
+				      "y": "37.55406888733184"
+				    }
+				  ],
+				  "meta": {
+				    "is_end": false,
+				    "pageable_count": 45,
+				    "same_name": {
+				      "keyword": "서울역",
+				      "region": [],
+				      "selected_region": ""
+				    },
+				    "total_count": 19574
+				  }
+				}
+				""";
+
+			URI uri = UriComponentsBuilder.fromUriString(KEYWORD_SEARCH_API_URI)
+				.queryParam("page", 1)
+				.queryParam("size", 1)
+				.queryParam("query", keyword)
+				.queryParam("sort", ACCURACY_SORT)
+				.encode(StandardCharsets.UTF_8)
+				.build().toUri();
+
+			// mocking kakao api response
+			mockServer.expect(requestTo(uri))
+				.andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+			// When & Then
+			String lat = "lat";
+			String lon = "lon";
+			Double valueX = 126.97070335253385;
+			Double valueY = 37.55406888733184;
+
+			Map<String, Double> response = kakaoPlaceSearchService.search(keyword);
+
+			assertThat(response)
+				.containsKey(lon)
+				.containsKey(lat)
+				.containsEntry(lon, valueX)
+				.containsEntry(lat, valueY);
+		}
+
+		@DisplayName("카카오 키워드 서치 API 호출 - 응답 데이터가 존재하지 않는 케이스")
+		@Test
+		void test() {
+			// given
+
+			// when
+
+			// then
+		}
+
+	}
+
+}


### PR DESCRIPTION
[CHORE] .gitignore 수정 : .env 중복 라인 삭제
[FEAT] TMAP 키워드 검색을 통한 위경도 변환 -> 카카오 API 키워드 검색을 통한 위경도 변환
[FEAT] ChatMemory 추가 -> 10개까지 대화 기억합니다. 이후에 유저별로 대화 저장하도록 수정할게요